### PR TITLE
PHPUnit と PHPCS を導入する (#31)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -17,6 +17,7 @@ bin
 .circleci/config.yml
 composer.json
 composer.lock
+composer.phar
 dependencies.yml
 Gruntfile.js
 package.json
@@ -42,3 +43,6 @@ node_modules
 .wp-env.json
 .github
 .wordpress-org
+.phpunit.cache
+.phpcs-cache
+CLAUDE.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - trunk
+  pull_request:
+
+jobs:
+  phpcs:
+    name: PHPCS (WordPress Coding Standards)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: composer
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.1-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-8.1-composer-
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Run PHPCS
+        run: composer phpcs -- --report=full
+
+  phpunit:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Run PHPUnit
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@ vendor/
 .DS_Store
 phpcs.xml
 phpunit.xml
+.phpunit.cache/
+.phpcs-cache
 Thumbs.db
 wp-cli.local.yml
 node_modules/
 *.sql
 *.tar.gz
 *.zip
+CLAUDE.md

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,10 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "7.4"
+        }
     },
     "scripts": {
         "test": "phpunit",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,41 @@
+{
+    "name": "mt8/base-item-list",
+    "description": "Display BASE(https://thebase.in/) Item List by shortcode [BASE_ITEM]",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "homepage": "https://github.com/mt8/base-item-list",
+    "require": {
+        "php": ">=7.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6",
+        "brain/monkey": "^2.6",
+        "mockery/mockery": "^1.6",
+        "yoast/phpunit-polyfills": "^2.0",
+        "squizlabs/php_codesniffer": "^3.9",
+        "wp-coding-standards/wpcs": "^3.1",
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "mt8\\BaseItemList\\": "includes/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "mt8\\BaseItemList\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "phpunit",
+        "phpcs": "phpcs",
+        "phpcbf": "phpcbf"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d37c87f8ae5ecbe34097a53c0ccdb10c",
+    "content-hash": "9fe64f56ba5e43d7a339e632925faa32",
     "packages": [],
     "packages-dev": [
         {
@@ -223,30 +223,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -273,7 +273,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -289,7 +289,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -2758,5 +2758,8 @@
         "php": ">=7.4"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2762 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d37c87f8ae5ecbe34097a53c0ccdb10c",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "~1.3.6 || ~1.4.4 || ~1.5.1 || ^1.6.10",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.49 || ^9.6.30"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/api.php"
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
+                "source": "https://github.com/Brain-WP/BrainMonkey"
+            },
+            "time": "2026-02-05T09:22:14+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-19T17:43:28+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-10-18T00:05:59+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "b598aa890815b8df16363271b659d73280129101"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-12T23:06:57+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-12-08T14:27:58+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "suggest": {
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-11-25T12:08:04+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T05:13:49+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -48,9 +48,9 @@ class Admin {
 		}
 
 		if ( $do_auth ) {
-			if ( PHP_SESSION_ACTIVE !== session_status() ) {
-				@session_start();
-			}			
+			if ( PHP_SESSION_NONE === session_status() ) {
+				session_start();
+			}
 			$auth = new Auth();
 			$auth->authorize();
 		}
@@ -64,13 +64,13 @@ class Admin {
 			'manage_options',
 			'base_item_list_setting',
 			array( View::class, 'option_page' )
-		);		
+		);
 	}
 
-	public static function option( $key) {
+	public static function option( $key ) {
 		$option = get_option( self::OPTIONS_KEY, self::OPTIONS_DEFUALT );
 		if ( is_array( $option ) && array_key_exists( $key, $option ) ) {
-			return $option[$key];
+			return $option[ $key ];
 		} else {
 			return '';
 		}

--- a/includes/Admin/View.php
+++ b/includes/Admin/View.php
@@ -11,51 +11,52 @@ class View {
 
 		$key     = Admin::OPTIONS_KEY;
 		$group   = $key . '_group';
-		$section = $key . '_section'; 
-		register_setting( $group, $key, array( View::class, 'filter_setting' ) );
+		$section = $key . '_section';
+		register_setting( $group, $key, array( self::class, 'filter_setting' ) );
 
 		add_settings_section(
 			$section,
 			'設定',
-			array( View::class, 'settings_section' ), $key
+			array( self::class, 'settings_section' ),
+			$key
 		);
 
 		add_settings_field(
-			'client_id'
-			,'client_id',
-			array( View::class, 'field_client_id' ), 
+			'client_id',
+			'client_id',
+			array( self::class, 'field_client_id' ),
 			$key,
 			$section
 		);
 
 		add_settings_field(
-			'client_secret'
-			,'client_secret',
-			array( View::class, 'field_client_secret' ), 
+			'client_secret',
+			'client_secret',
+			array( self::class, 'field_client_secret' ),
 			$key,
 			$section
 		);
 
 		add_settings_field(
-			'callback_url'
-			,'コールバックURL',
-			array( View::class, 'field_callback_url' ), 
+			'callback_url',
+			'コールバックURL',
+			array( self::class, 'field_callback_url' ),
 			$key,
 			$section
 		);
 
 		add_settings_field(
-			'shop_url'
-			,'ショップURL',
-			array( View::class, 'field_shop_url' ), 
+			'shop_url',
+			'ショップURL',
+			array( self::class, 'field_shop_url' ),
 			$key,
 			$section
 		);
 
 		add_settings_field(
-			'use_default_css'
-			,'プラグインCSSを使用する',
-			array( View::class, 'field_use_default_css' ), 
+			'use_default_css',
+			'プラグインCSSを使用する',
+			array( self::class, 'field_use_default_css' ),
 			$key,
 			$section
 		);
@@ -68,12 +69,12 @@ class View {
 			}
 		}
 		return $input;
-	}	
+	}
 
 	public static function option_page() {
 		$admin = new Admin();
-		$auth = new Auth();
-	?>
+		$auth  = new Auth();
+		?>
 	<div class="wrap">
 
 		<h2>BASE商品リスト API設定</h2>
@@ -102,8 +103,8 @@ class View {
 				</td>
 				<td width="45%">
 					<p>※クリックで拡大します</p>
-					<a target="_blank" href="<?php echo plugins_url( '/assets/images/api-apply.png', dirname( dirname( __FILE__ ) ) ) ?>">
-					<img width="70%" src="<?php echo plugins_url( '/assets/images/api-apply.png', dirname( dirname( __FILE__ ) ) ) ?>">
+					<a target="_blank" href="<?php echo esc_url( plugins_url( '/assets/images/api-apply.png', dirname( __DIR__ ) ) ); ?>">
+					<img width="70%" src="<?php echo esc_url( plugins_url( '/assets/images/api-apply.png', dirname( __DIR__ ) ) ); ?>">
 					</a>
 				</td>
 			</tr>
@@ -117,10 +118,11 @@ class View {
 		</form>
 		<hr />
 
-		<?php if ( $admin->saved_options() ) :
+		<?php
+		if ( $admin->saved_options() ) :
 			$callbak_url = add_query_arg( array( 'force' => '1' ), Admin::option( 'callback_url' ) );
-		?>
-		<form method="POST" action="<?php echo esc_url( $callbak_url ) ?>" >
+			?>
+		<form method="POST" action="<?php echo esc_url( $callbak_url ); ?>" >
 			<?php wp_nonce_field( 'base_item_list_auth', 'base_item_list_auth' ); ?>			
 			<?php if ( $auth->authorized() ) : ?>
 				<h2>API認証(認証済)</h2>
@@ -206,46 +208,54 @@ class View {
 
 		<?php $last_error = get_option( Core::LAST_ERROR_OPTION_KEY ); if ( ! empty( $last_error ) ) : ?>
 		<h2>エラーログ</h2>
-		<code><?php echo esc_html( $last_error ) ?></code>
-		<?php endif ; ?>
+		<code><?php echo esc_html( $last_error ); ?></code>
+		<?php endif; ?>
 	</div>		
-	<?php
+		<?php
 	}
 
-	public static function settings_section() { ?>
+	public static function settings_section() {
+
+		?>
 		<?php
-		if ( 'true' === filter_input( INPUT_GET, 'settings-updated' ) ) { ?>
+		if ( 'true' === filter_input( INPUT_GET, 'settings-updated' ) ) {
+			?>
 		<div class="updated"><p>設定を保存しました。</p></div>
-		<?php
+			<?php
 		}
-		if ( 'authorized' === filter_input( INPUT_GET, 'status' ) ) { ?>
+		if ( 'authorized' === filter_input( INPUT_GET, 'status' ) ) {
+			?>
 		<div class="updated"><p>API認証が完了しました。</p></div>
-		<?php
+			<?php
 		}
 	}
 
-	public static function field_client_id() { ?>
+	public static function field_client_id() {
+
+		?>
 		<input 
 			type="text" 
 			id="client_id" 
-			name="<?php echo Admin::OPTIONS_KEY ?>[client_id]" 
+			name="<?php echo esc_attr( Admin::OPTIONS_KEY ); ?>[client_id]" 
 			class="regular-text" 
-			value="<?php echo esc_attr( Admin::option( 'client_id' ) ) ?>" 
+			value="<?php echo esc_attr( Admin::option( 'client_id' ) ); ?>" 
 		/>
-	<?php
+		<?php
 	}
-	
-	public static function field_client_secret() { ?>
+
+	public static function field_client_secret() {
+
+		?>
 		<input 
 			type="text" 
 			id="client_secret" 
-			name="<?php echo Admin::OPTIONS_KEY ?>[client_secret]" 
+			name="<?php echo esc_attr( Admin::OPTIONS_KEY ); ?>[client_secret]" 
 			class="regular-text" 
-			value="<?php echo esc_attr( Admin::option( 'client_secret' ) ) ?>" 
+			value="<?php echo esc_attr( Admin::option( 'client_secret' ) ); ?>" 
 		/>
-	<?php
+		<?php
 	}
-	
+
 	public static function field_callback_url() {
 
 		$auth_url = add_query_arg(
@@ -262,7 +272,7 @@ class View {
 			type="hidden" 
 			readonly
 			id="callback_url"
-			name="<?php echo Admin::OPTIONS_KEY ?>[callback_url]" 
+			name="<?php echo esc_attr( Admin::OPTIONS_KEY ); ?>[callback_url]" 
 			class="regular-text" 
 			value="<?php echo esc_url( $auth_url ); ?>" 
 		/>
@@ -273,29 +283,32 @@ class View {
 				return false;
 			}
 		</script>
-	<?php
+		<?php
 	}
-	
-	public static function field_shop_url() { ?>
+
+	public static function field_shop_url() {
+
+		?>
 		<input 
 			type="text" 
 			id="shop_url" 
-			name="<?php echo Admin::OPTIONS_KEY ?>[shop_url]" 
+			name="<?php echo esc_attr( Admin::OPTIONS_KEY ); ?>[shop_url]" 
 			class="regular-text" 
-			value="<?php echo esc_attr( Admin::option( 'shop_url' ) ) ?>" 
+			value="<?php echo esc_attr( Admin::option( 'shop_url' ) ); ?>" 
 		/>
-	<?php
+		<?php
 	}
 
-	public static function field_use_default_css() { ?>
+	public static function field_use_default_css() {
+
+		?>
 		<input 
 			type="checkbox" 
 			id="use_default_css" 
-			name="<?php echo Admin::OPTIONS_KEY ?>[use_default_css]" 
+			name="<?php echo esc_attr( Admin::OPTIONS_KEY ); ?>[use_default_css]" 
 			value="1" 
 			<?php checked( Admin::option( 'use_default_css' ), 1 ); ?>
 		/>
-	<?php
+		<?php
 	}
-
 }

--- a/includes/Auth.php
+++ b/includes/Auth.php
@@ -6,11 +6,11 @@ use mt8\BaseItemList\Admin\Admin;
 
 class Auth {
 
-	const BASE_API_AUTH_URL = 'https://api.thebase.in/1/oauth/authorize';
+	const BASE_API_AUTH_URL  = 'https://api.thebase.in/1/oauth/authorize';
 	const BASE_API_TOKEN_URL = 'https://api.thebase.in/1/oauth/token';
 
 	const ACCESS_TOKEN_TRANSIENT_KEY = 'base-item-list-access-token';
-	const REFRESH_TOKEN_OPTION_KEY = 'base-item-list-refresh-token';
+	const REFRESH_TOKEN_OPTION_KEY   = 'base-item-list-refresh-token';
 
 	public function authorize() {
 
@@ -32,38 +32,44 @@ class Auth {
 		wp_safe_redirect( $admin_url, 301 );
 		exit;
 	}
-	
+
 	public function get_auth_code() {
 		if ( ! empty( filter_input( INPUT_GET, 'code' ) ) ) {
-			if ( $_SESSION['oauth_state'] !== filter_input( INPUT_GET, 'state' ) ) {
+			$session_state = isset( $_SESSION['oauth_state'] )
+				? sanitize_text_field( wp_unslash( (string) $_SESSION['oauth_state'] ) )
+				: '';
+			if ( $session_state !== filter_input( INPUT_GET, 'state' ) ) {
 				wp_die( 'Bad Request' );
-				exit;
 			}
 			unset( $_SESSION['oauth_state'] );
 			return filter_input( INPUT_GET, 'code' );
 		}
 
-		$state = base64_encode( wp_generate_password( 12, true ,true ) );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- benign URL-safe state token, not for obfuscation.
+		$state                   = base64_encode( wp_generate_password( 12, true, true ) );
 		$_SESSION['oauth_state'] = $state;
 
-		$client_id = Admin::option( 'client_id' );
+		$client_id    = Admin::option( 'client_id' );
 		$callback_url = Admin::option( 'callback_url' );
 
 		$auth_url = add_query_arg(
 			array(
 				'response_type' => 'code',
 				'client_id'     => $client_id,
-				'redirect_uri'  => urlencode( $callback_url ),
+				'redirect_uri'  => rawurlencode( $callback_url ),
 				'scope'         => 'read_items',
 				'state'         => $state,
 			),
 			self::BASE_API_AUTH_URL
 		);
 
-		add_filter( 'allowed_redirect_hosts', function ( $allowed ) {
-			$allowed[] = parse_url( self::BASE_API_AUTH_URL, PHP_URL_HOST );
-			return $allowed;
-		});
+		add_filter(
+			'allowed_redirect_hosts',
+			function ( $allowed ) {
+				$allowed[] = wp_parse_url( self::BASE_API_AUTH_URL, PHP_URL_HOST );
+				return $allowed;
+			}
+		);
 
 		wp_safe_redirect( $auth_url, 301 );
 		exit;
@@ -78,9 +84,9 @@ class Auth {
 			}
 		}
 
-		$client_id = Admin::option( 'client_id' );
+		$client_id     = Admin::option( 'client_id' );
 		$client_secret = Admin::option( 'client_secret' );
-		$callback_url = Admin::option( 'callback_url' );
+		$callback_url  = Admin::option( 'callback_url' );
 
 		$refresh_token = get_option( self::REFRESH_TOKEN_OPTION_KEY );
 		if ( empty( $refresh_token ) ) {
@@ -90,15 +96,15 @@ class Auth {
 					'headers' => array(
 						'Content-Type: application/x-www-form-urlencoded',
 					),
-					'body' => array(
+					'body'    => array(
 						'grant_type'    => 'authorization_code',
 						'client_id'     => $client_id,
 						'client_secret' => $client_secret,
 						'code'          => $code,
 						'redirect_uri'  => $callback_url,
-					)
+					),
 				)
-			);	
+			);
 		} else {
 			$res = wp_remote_post(
 				self::BASE_API_TOKEN_URL,
@@ -106,22 +112,22 @@ class Auth {
 					'headers' => array(
 						'Content-Type: application/x-www-form-urlencoded',
 					),
-					'body' => array(
+					'body'    => array(
 						'grant_type'    => 'refresh_token',
 						'client_id'     => $client_id,
 						'client_secret' => $client_secret,
 						'refresh_token' => $refresh_token,
 						'redirect_uri'  => $callback_url,
-					)
+					),
 				)
-			);				
+			);
 		}
 
 		if ( 200 === wp_remote_retrieve_response_code( $res ) ) {
 
 			$json = json_decode( wp_remote_retrieve_body( $res ) );
 
-			$token = $json->access_token;
+			$token         = $json->access_token;
 			$refresh_token = $json->refresh_token;
 
 			set_transient( self::ACCESS_TOKEN_TRANSIENT_KEY, $token, $json->expires_in );
@@ -137,5 +143,4 @@ class Auth {
 	public function authorized() {
 		return ( true !== empty( $this->get_access_token( '', false ) ) );
 	}
-
 }

--- a/includes/Core.php
+++ b/includes/Core.php
@@ -7,22 +7,21 @@ use mt8\BaseItemList\Admin\Admin;
 use mt8\BaseItemList\Admin\View;
 
 class Core {
-		
-	const BASE_API_ITEMS_URL = 'https://api.thebase.in/1/items/search';
+
+	const BASE_API_ITEMS_URL    = 'https://api.thebase.in/1/items/search';
 	const LAST_ERROR_OPTION_KEY = 'base-item-list-last-error';
 
 	public function register_hooks() {
 
-		$admin = New Admin();
+		$admin = new Admin();
 
 		add_action( 'admin_init', array( $admin, 'admin_init' ) );
 		add_action( 'admin_menu', array( $admin, 'admin_menu' ) );
 		add_action( 'admin_init', array( View::class, 'register_setting_fields' ) );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'wp_enqueue_scripts' ) );
-		
-		add_shortcode('BASE_ITEM', array( $this, 'add_shortcode' ) );
 
+		add_shortcode( 'BASE_ITEM', array( $this, 'add_shortcode' ) );
 	}
 
 	public function add_shortcode( $atts ) {
@@ -35,8 +34,7 @@ class Core {
 				'categories',
 			);
 
-			//setup parameter
-			extract( shortcode_atts( 
+			$params = shortcode_atts(
 				array(
 					'q'      => '*',
 					'fields' => implode( ',', $fields_default ),
@@ -45,19 +43,28 @@ class Core {
 					'limit'  => 10,
 					'cache'  => 60,
 					'name'   => 'cache',
-				), $atts ) );
+				),
+				$atts
+			);
+			$q      = $params['q'];
+			$fields = $params['fields'];
+			$order  = $params['order'];
+			$sort   = $params['sort'];
+			$limit  = $params['limit'];
+			$cache  = $params['cache'];
+			$name   = $params['name'];
 
-			// check parameter
+			// Validate parameters; fall back to defaults on bad input.
 			$fields_check = explode( ',', $fields );
 			foreach ( $fields_check as $field ) {
-				if ( ! in_array( $field, $fields_default ) ) {
+				if ( ! in_array( $field, $fields_default, true ) ) {
 					$fields = implode( ',', $fields_default );
 				}
 			}
-			if ( ! in_array( $order, array( 'list_order', 'modified' ) ) ) {
+			if ( ! in_array( $order, array( 'list_order', 'modified' ), true ) ) {
 				$order = '';
 			}
-			if ( ! in_array( $sort, array( 'asc', 'desc' ) ) ) {
+			if ( ! in_array( $sort, array( 'asc', 'desc' ), true ) ) {
 				$sort = 'desc';
 			}
 			if ( 0 >= intval( $limit ) || $limit > 100 ) {
@@ -67,7 +74,7 @@ class Core {
 				$cache = 60;
 			}
 
-			//call API if no cache
+			// call API if no cache
 			$json = get_transient( 'base-item-list-' . md5( $name ) );
 			if ( ! $json ) {
 				$json = $this->request_api( compact( 'q', 'fields', 'order', 'sort', 'limit' ) );
@@ -79,7 +86,7 @@ class Core {
 				}
 			}
 
-			//print items
+			// print items
 			return $this->item_list( $json->items );
 
 		} catch ( Exception $ex ) {
@@ -88,9 +95,8 @@ class Core {
 			update_option( self::LAST_ERROR_OPTION_KEY, 'エラー:' . $ex->getMessage(), false );
 			return '';
 		}
-
 	}
-	
+
 	public function request_api( $args ) {
 
 		$auth = new Auth();
@@ -104,16 +110,16 @@ class Core {
 		}
 
 		$args = array(
-			'headers'     => array(
+			'headers' => array(
 				'Authorization' => 'Bearer ' . $token,
 			),
-			'body' => array(
+			'body'    => array(
 				'q'      => $args['q'],
 				'fields' => $args['fields'],
 				'order'  => $args['order'],
 				'sort'   => $args['sort'],
 				'limit'  => $args['limit'],
-			)
+			),
 		);
 
 		$response = wp_remote_get( self::BASE_API_ITEMS_URL, $args );
@@ -124,44 +130,44 @@ class Core {
 			error_log( 'Response Code:    ' . wp_remote_retrieve_response_code( $response ) );
 			error_log( 'Response Message: ' . wp_remote_retrieve_response_message( $response ) );
 			update_option(
-				self::LAST_ERROR_OPTION_KEY, var_export( $args, true ) . PHP_EOL .
-				'(' . wp_remote_retrieve_response_code( $response ) . ')' . 
-				wp_remote_retrieve_response_message( $response ) , false );
+				self::LAST_ERROR_OPTION_KEY,
+				var_export( $args, true ) . PHP_EOL .
+				'(' . wp_remote_retrieve_response_code( $response ) . ')' .
+				wp_remote_retrieve_response_message( $response ),
+				false
+			);
 			return null;
 		}
 
 		return json_decode( wp_remote_retrieve_body( $response ) );
 	}
-	
+
 	public function item_list( $items ) {
-		
-		//set globals
-		$GLOBALS[ 'base_items' ] = $items;
+
+		// set globals
+		$GLOBALS['base_items'] = $items;
 
 		foreach ( $items as $index => $item ) {
-			$items[$index]->shop_url = untrailingslashit( Admin::option('shop_url') );
+			$items[ $index ]->shop_url = untrailingslashit( Admin::option( 'shop_url' ) );
 		}
-		
-		 ob_start();
+
+		ob_start();
 		if ( is_file( get_stylesheet_directory() . '/base_items.php' ) ) {
-			//load base_items.php in your theme.
+			// load base_items.php in your theme.
 			get_template_part( 'base_items' );
 		} else {
-			//load base_items.php in this plugin.
-			include dirname(__DIR__) . '/template/base_items.php';
+			// load base_items.php in this plugin.
+			include dirname( __DIR__ ) . '/template/base_items.php';
 		}
 		return ob_get_clean();
-
 	}
 
 	public function wp_enqueue_scripts() {
-		$admin = New Admin();
-		if ( true || '1' == $admin->option( 'use_default_css' ) ) {
-			wp_enqueue_style(
-				'base-item-list',
-				plugins_url( '/assets/css/base-item-list.css', dirname(__FILE__) )
-			);
-		}
+		// The default stylesheet is always enqueued; the `use_default_css` option is currently
+		// a no-op kept for backwards compatibility with stored settings.
+		wp_enqueue_style(
+			'base-item-list',
+			plugins_url( '/assets/css/base-item-list.css', __DIR__ )
+		);
 	}
-
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<ruleset name="BASE Item List">
+	<description>Coding standards for the BASE Item List plugin.</description>
+
+	<file>plugin.php</file>
+	<file>includes</file>
+	<file>template</file>
+
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/assets/*</exclude-pattern>
+
+	<arg name="basepath" value="."/>
+	<arg name="colors"/>
+	<arg name="extensions" value="php"/>
+	<arg value="sp"/>
+	<arg name="parallel" value="8"/>
+
+	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="testVersion" value="7.4-"/>
+
+	<rule ref="WordPress">
+		<!-- Filenames use PascalCase to match the PSR-4 class layout. -->
+		<exclude name="WordPress.Files.FileName"/>
+		<!-- Stylistic comment punctuation is not enforced. -->
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+		<!-- The plugin pre-dates Yoda; not worth churning. -->
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+		<!-- error_log() and var_export() are used intentionally to surface API errors. -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_error_log"/>
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_var_export"/>
+		<!-- Strict in_array() comparisons are not required for these small fixed allow-lists. -->
+		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict"/>
+		<!-- Resource versioning is delegated to wp.org's plugin version. -->
+		<exclude name="WordPress.WP.EnqueuedResourceParameters.MissingVersion"/>
+		<!-- Project convention: keep docblocks light. Public APIs are documented inline where helpful. -->
+		<exclude name="Squiz.Commenting.FileComment.Missing"/>
+		<exclude name="Squiz.Commenting.FileComment.WrongStyle"/>
+		<exclude name="Squiz.Commenting.ClassComment.Missing"/>
+		<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+		<exclude name="Squiz.Commenting.VariableComment.Missing"/>
+		<!-- The default template intentionally documents the API response shape with a block comment. -->
+		<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
+		<exclude name="Squiz.Commenting.BlockComment.NoEmptyLineBefore"/>
+	</rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="base-item-list"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="PHPCompatibilityWP"/>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="true"
+	beStrictAboutOutputDuringTests="true"
+	failOnWarning="true"
+	failOnRisky="true"
+	cacheResultFile=".phpunit.cache/test-results"
+	executionOrder="depends,defects"
+>
+	<testsuites>
+		<testsuite name="unit">
+			<directory>tests/Unit</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
+			<directory suffix=".php">includes</directory>
+		</include>
+	</coverage>
+	<php>
+		<ini name="error_reporting" value="-1"/>
+		<ini name="log_errors" value="0"/>
+		<ini name="error_log" value="/dev/null"/>
+		<server name="APP_ENV" value="testing"/>
+	</php>
+</phpunit>

--- a/plugin.php
+++ b/plugin.php
@@ -9,19 +9,24 @@
 	Domain Path: /languages
 	Text Domain: base-item-list
 */
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-add_action( 'admin_menu', function() {
-	$admin_view = new \mt8\BaseItemList\Admin\View();
-	add_menu_page(
-		'BASE Item List',
-		'BASE Item List' ,
-		'manage_options',
-		'base_item_list',
-		array( $admin_view, 'option_page' ),
-		'dashicons-cart'
-	);
-});
+add_action(
+	'admin_menu',
+	function () {
+		$admin_view = new \mt8\BaseItemList\Admin\View();
+		add_menu_page(
+			'BASE Item List',
+			'BASE Item List',
+			'manage_options',
+			'base_item_list',
+			array( $admin_view, 'option_page' ),
+			'dashicons-cart'
+		);
+	}
+);
 
 require_once __DIR__ . '/includes/Core.php';
 require_once __DIR__ . '/includes/Admin/Admin.php';

--- a/template/base_items.php
+++ b/template/base_items.php
@@ -1,9 +1,11 @@
 <?php
-	if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 	global $base_items;
 	/*
 	Array
-	(	
+	(
 		[n] => stdClass Object
 		(
 			[item_id] => int
@@ -16,7 +18,7 @@
 			[stock] => int
 			[visible] => int
 			[list_order] => int
-			[identifier] => 
+			[identifier] =>
 			[modified] => 1601540864
 
 			[img(1-5)_origin] => string
@@ -63,7 +65,7 @@
 			<li class="base_item">
 				<dt><span class="base_item_title"><?php echo esc_html( $item->title ); ?></span></dt>
 				<dd>
-					<a href="<?php echo esc_url( $item->shop_url) ?>/items/<?php echo $item->item_id; ?>" target="_blank">
+					<a href="<?php echo esc_url( $item->shop_url ); ?>/items/<?php echo (int) $item->item_id; ?>" target="_blank">
 						<img src="<?php echo esc_url( $item->img1_300 ); ?>" alt="<?php echo esc_attr( $item->title ); ?>">
 					</a>
 				</dd>
@@ -72,4 +74,5 @@
 		</ul>
 	</div><!--/.base_items-->
 
-<?php endif;
+	<?php
+endif;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Base test case wiring Brain Monkey into PHPUnit.
+ *
+ * @package mt8\BaseItemList\Tests
+ */
+
+namespace mt8\BaseItemList\Tests;
+
+use Brain\Monkey;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase as PolyfillsTestCase;
+
+abstract class TestCase extends PolyfillsTestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function set_up() {
+		parent::set_up();
+		Monkey\setUp();
+		$this->stub_common_wp_functions();
+	}
+
+	protected function tear_down() {
+		Monkey\tearDown();
+		parent::tear_down();
+	}
+
+	/**
+	 * Stub WordPress helpers that are pure / commonly used so tests don't repeat themselves.
+	 *
+	 * Tests can override any of these with Functions\when()/expect() inside the test.
+	 */
+	private function stub_common_wp_functions(): void {
+		Monkey\Functions\stubs(
+			array(
+				'__'             => null,
+				'_e'             => null,
+				'esc_html'       => null,
+				'esc_attr'       => null,
+				'esc_url'        => null,
+				'esc_html__'     => null,
+				'esc_attr__'     => null,
+				'wp_kses_post'   => null,
+				'untrailingslashit' => static function ( $string ) {
+					return rtrim( (string) $string, '/\\' );
+				},
+				'sanitize_text_field' => static function ( $string ) {
+					return is_string( $string ) ? trim( $string ) : '';
+				},
+			)
+		);
+	}
+}

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Tests for mt8\BaseItemList\Admin\Admin.
+ *
+ * @package mt8\BaseItemList\Tests
+ */
+
+namespace mt8\BaseItemList\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use mt8\BaseItemList\Admin\Admin;
+use mt8\BaseItemList\Tests\TestCase;
+
+class AdminTest extends TestCase {
+
+	public function test_option_returns_stored_value_for_known_key(): void {
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'client_id'     => 'the-client',
+				'client_secret' => 'shh',
+				'callback_url'  => 'https://example.test/cb',
+				'shop_url'      => 'https://shop.example/',
+			)
+		);
+
+		$this->assertSame( 'the-client', Admin::option( 'client_id' ) );
+		$this->assertSame( 'https://shop.example/', Admin::option( 'shop_url' ) );
+	}
+
+	public function test_option_returns_empty_string_for_unknown_key(): void {
+		Functions\when( 'get_option' )->justReturn( array( 'client_id' => 'x' ) );
+
+		$this->assertSame( '', Admin::option( 'no_such_key' ) );
+	}
+
+	public function test_option_returns_empty_string_when_option_is_not_an_array(): void {
+		Functions\when( 'get_option' )->justReturn( false );
+
+		$this->assertSame( '', Admin::option( 'client_id' ) );
+	}
+
+	public function test_saved_options_returns_true_when_all_required_fields_are_present(): void {
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'client_id'     => 'a',
+				'client_secret' => 'b',
+				'callback_url'  => 'c',
+				'shop_url'      => 'd',
+			)
+		);
+
+		$this->assertTrue( ( new Admin() )->saved_options() );
+	}
+
+	public function test_saved_options_returns_false_when_any_required_field_is_empty(): void {
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'client_id'     => 'a',
+				'client_secret' => '',
+				'callback_url'  => 'c',
+				'shop_url'      => 'd',
+			)
+		);
+
+		$this->assertFalse( ( new Admin() )->saved_options() );
+	}
+
+	public function test_saved_options_returns_false_when_required_field_is_missing(): void {
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'client_id'     => 'a',
+				'client_secret' => 'b',
+				// callback_url missing.
+				'shop_url'      => 'd',
+			)
+		);
+
+		$this->assertFalse( ( new Admin() )->saved_options() );
+	}
+
+	public function test_admin_init_skips_when_request_is_not_for_settings_page(): void {
+		global $pagenow;
+		$pagenow = 'plugins.php';
+		unset( $_GET['page'] );
+
+		// No auth flow should run; the test passes as long as admin_init returns without errors.
+		( new Admin() )->admin_init();
+		$this->assertTrue( true );
+	}
+
+	public function test_admin_menu_adds_submenu_page(): void {
+		Functions\expect( 'add_submenu_page' )
+			->once()
+			->with(
+				'base_item_list',
+				'API設定',
+				'API設定',
+				'manage_options',
+				'base_item_list_setting',
+				\Mockery::type( 'array' )
+			);
+
+		( new Admin() )->admin_menu();
+	}
+}

--- a/tests/Unit/AuthTest.php
+++ b/tests/Unit/AuthTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for mt8\BaseItemList\Auth.
+ *
+ * @package mt8\BaseItemList\Tests
+ */
+
+namespace mt8\BaseItemList\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use mt8\BaseItemList\Admin\Admin;
+use mt8\BaseItemList\Auth;
+use mt8\BaseItemList\Tests\TestCase;
+
+class AuthTest extends TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+
+		Functions\when( 'get_option' )->alias(
+			static function ( $key, $default = false ) {
+				if ( Admin::OPTIONS_KEY === $key ) {
+					return array(
+						'client_id'     => 'cid',
+						'client_secret' => 'sec',
+						'callback_url'  => 'https://cb.example/',
+					);
+				}
+				if ( Auth::REFRESH_TOKEN_OPTION_KEY === $key ) {
+					return '';
+				}
+				return $default;
+			}
+		);
+	}
+
+	/**
+	 * Stubs the two write paths so individual tests don't have to repeat them.
+	 *
+	 * Call this in tests where set_transient / update_option args are NOT being verified.
+	 * In tests that verify args via Functions\expect(), don't call this — `when()` would
+	 * shadow the expectation in Brain Monkey.
+	 */
+	private function ignore_token_writes(): void {
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'update_option' )->justReturn( true );
+	}
+
+	public function test_get_access_token_returns_cached_token_when_available(): void {
+		Functions\when( 'get_transient' )->alias(
+			static function ( $key ) {
+				return Auth::ACCESS_TOKEN_TRANSIENT_KEY === $key ? 'cached-token' : false;
+			}
+		);
+		Functions\expect( 'wp_remote_post' )->never();
+
+		$this->assertSame( 'cached-token', ( new Auth() )->get_access_token() );
+	}
+
+	public function test_get_access_token_requests_token_with_authorization_code_when_no_refresh_token(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\expect( 'wp_remote_post' )
+			->once()
+			->with(
+				Auth::BASE_API_TOKEN_URL,
+				\Mockery::on(
+					static function ( $args ) {
+						return 'authorization_code' === $args['body']['grant_type']
+							&& 'cid' === $args['body']['client_id']
+							&& 'sec' === $args['body']['client_secret']
+							&& 'auth-code' === $args['body']['code']
+							&& 'https://cb.example/' === $args['body']['redirect_uri'];
+					}
+				)
+			)
+			->andReturn( array( 'body' => '{"access_token":"new-tok","refresh_token":"rt","expires_in":3600}' ) );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"access_token":"new-tok","refresh_token":"rt","expires_in":3600}' );
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( Auth::ACCESS_TOKEN_TRANSIENT_KEY, 'new-tok', 3600 );
+		Functions\expect( 'update_option' )
+			->once()
+			->with( Auth::REFRESH_TOKEN_OPTION_KEY, 'rt' );
+
+		$this->assertSame( 'new-tok', ( new Auth() )->get_access_token( 'auth-code' ) );
+	}
+
+	public function test_get_access_token_uses_refresh_grant_when_refresh_token_exists(): void {
+		$this->ignore_token_writes();
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'get_option' )->alias(
+			static function ( $key, $default = false ) {
+				if ( Admin::OPTIONS_KEY === $key ) {
+					return array(
+						'client_id'     => 'cid',
+						'client_secret' => 'sec',
+						'callback_url'  => 'https://cb.example/',
+					);
+				}
+				if ( Auth::REFRESH_TOKEN_OPTION_KEY === $key ) {
+					return 'existing-refresh';
+				}
+				return $default;
+			}
+		);
+		Functions\expect( 'wp_remote_post' )
+			->once()
+			->with(
+				Auth::BASE_API_TOKEN_URL,
+				\Mockery::on(
+					static function ( $args ) {
+						return 'refresh_token' === $args['body']['grant_type']
+							&& 'existing-refresh' === $args['body']['refresh_token'];
+					}
+				)
+			)
+			->andReturn( array( 'body' => '{"access_token":"refreshed","refresh_token":"new-refresh","expires_in":60}' ) );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"access_token":"refreshed","refresh_token":"new-refresh","expires_in":60}' );
+
+		$this->assertSame( 'refreshed', ( new Auth() )->get_access_token() );
+	}
+
+	public function test_get_access_token_returns_null_on_non_200_response(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_remote_post' )->justReturn( array() );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 400 );
+
+		$this->assertNull( ( new Auth() )->get_access_token( 'bad-code' ) );
+	}
+
+	public function test_get_access_token_bypasses_cache_when_use_cache_is_false(): void {
+		$this->ignore_token_writes();
+		// Even when the cache is populated, $use_cache=false should re-negotiate.
+		Functions\when( 'get_transient' )->justReturn( 'old-cached' );
+		Functions\expect( 'wp_remote_post' )
+			->once()
+			->andReturn( array() );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"access_token":"renewed","refresh_token":"r","expires_in":1}' );
+
+		$this->assertSame( 'renewed', ( new Auth() )->get_access_token( '', false ) );
+	}
+
+	public function test_authorized_returns_true_when_token_obtainable(): void {
+		$this->ignore_token_writes();
+		// $use_cache=false path: authorized() asks for a fresh token.
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_remote_post' )->justReturn( array() );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"access_token":"t","refresh_token":"r","expires_in":1}' );
+
+		$this->assertTrue( ( new Auth() )->authorized() );
+	}
+
+	public function test_authorized_returns_false_when_token_unobtainable(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_remote_post' )->justReturn( array() );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 401 );
+
+		$this->assertFalse( ( new Auth() )->authorized() );
+	}
+}

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * Tests for mt8\BaseItemList\Core.
+ *
+ * @package mt8\BaseItemList\Tests
+ */
+
+namespace mt8\BaseItemList\Tests\Unit;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use mt8\BaseItemList\Admin\Admin;
+use mt8\BaseItemList\Auth;
+use mt8\BaseItemList\Core;
+use mt8\BaseItemList\Tests\TestCase;
+
+class CoreTest extends TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+
+		Functions\when( 'shortcode_atts' )->alias(
+			static function ( $defaults, $atts ) {
+				$atts = is_array( $atts ) ? $atts : array();
+				return array_merge( $defaults, $atts );
+			}
+		);
+		Functions\when( 'plugins_url' )->alias(
+			static function ( $path, $base ) {
+				return 'https://example.test' . $path;
+			}
+		);
+		Functions\when( 'get_stylesheet_directory' )->justReturn( '/tmp/does-not-exist' );
+	}
+
+	public function test_register_hooks_registers_expected_actions_and_shortcode(): void {
+		Actions\expectAdded( 'admin_init' )->twice();
+		Actions\expectAdded( 'admin_menu' )->once();
+		Actions\expectAdded( 'wp_enqueue_scripts' )->once();
+
+		Functions\expect( 'add_shortcode' )
+			->once()
+			->with( 'BASE_ITEM', \Mockery::type( 'array' ) );
+
+		( new Core() )->register_hooks();
+	}
+
+	public function test_add_shortcode_returns_rendered_items_from_cache(): void {
+		$cached = (object) array(
+			'items' => array(
+				(object) array(
+					'item_id'  => 1,
+					'title'    => 'cached title',
+					'img1_300' => 'https://img.example/1.jpg',
+				),
+			),
+		);
+		Functions\when( 'get_transient' )->justReturn( $cached );
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'get_option' )->alias(
+			static function ( $key, $default = false ) {
+				if ( Admin::OPTIONS_KEY === $key ) {
+					return array( 'shop_url' => 'https://shop.example/' );
+				}
+				return $default;
+			}
+		);
+
+		$core   = $this->partial_core_without_request_api();
+		$output = $core->add_shortcode( array() );
+
+		$this->assertStringContainsString( 'cached title', $output );
+		$this->assertStringContainsString( 'https://shop.example/items/1', $output );
+		$this->assertStringContainsString( 'https://img.example/1.jpg', $output );
+	}
+
+	public function test_add_shortcode_calls_api_when_cache_miss_and_caches_result(): void {
+		$response = (object) array(
+			'items' => array(
+				(object) array(
+					'item_id'  => 42,
+					'title'    => 'fresh',
+					'img1_300' => 'https://img.example/42.jpg',
+				),
+			),
+		);
+
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( \Mockery::pattern( '/^base-item-list-[a-f0-9]{32}$/' ), $response, 60 )
+			->andReturn( true );
+		Functions\when( 'get_option' )->justReturn( array( 'shop_url' => 'https://shop.example' ) );
+
+		$core = \Mockery::mock( Core::class )->makePartial();
+		$core->shouldReceive( 'request_api' )
+			->once()
+			->with(
+				\Mockery::on(
+					static function ( $args ) {
+						return is_array( $args )
+							&& '*' === $args['q']
+							&& 'title,detail,categories' === $args['fields']
+							&& '' === $args['order']
+							&& 'desc' === $args['sort']
+							&& 10 === $args['limit'];
+					}
+				)
+			)
+			->andReturn( $response );
+
+		$output = $core->add_shortcode( array() );
+
+		$this->assertStringContainsString( 'fresh', $output );
+	}
+
+	public function test_add_shortcode_returns_empty_string_when_api_returns_null(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'get_option' )->justReturn( array( 'shop_url' => '' ) );
+
+		$core = \Mockery::mock( Core::class )->makePartial();
+		$core->shouldReceive( 'request_api' )->once()->andReturn( null );
+
+		$this->assertSame( '', $core->add_shortcode( array() ) );
+	}
+
+	public function test_add_shortcode_falls_back_to_defaults_for_invalid_parameters(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'get_option' )->justReturn( array( 'shop_url' => '' ) );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$core = \Mockery::mock( Core::class )->makePartial();
+		$core->shouldReceive( 'request_api' )
+			->once()
+			->with(
+				\Mockery::on(
+					static function ( $args ) {
+						return 'title,detail,categories' === $args['fields'] // invalid field reset.
+							&& '' === $args['order'] // invalid order reset.
+							&& 'desc' === $args['sort'] // invalid sort reset.
+							&& 10 === $args['limit']; // out-of-range limit reset.
+					}
+				)
+			)
+			->andReturn( (object) array( 'items' => array() ) );
+
+		$core->add_shortcode(
+			array(
+				'fields' => 'evil,detail',
+				'order'  => 'bogus',
+				'sort'   => 'sideways',
+				'limit'  => 9999,
+				'cache'  => -1,
+			)
+		);
+	}
+
+	public function test_add_shortcode_resets_non_positive_cache_to_default_and_writes_transient(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'get_option' )->justReturn( array( 'shop_url' => '' ) );
+		// cache=-5 is reset to the 60s default by the validator, so set_transient IS called with 60.
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( \Mockery::type( 'string' ), \Mockery::type( 'object' ), 60 )
+			->andReturn( true );
+
+		$core = \Mockery::mock( Core::class )->makePartial();
+		$core->shouldReceive( 'request_api' )->andReturn( (object) array( 'items' => array() ) );
+
+		$core->add_shortcode( array( 'cache' => '-5' ) );
+	}
+
+	public function test_add_shortcode_returns_empty_and_logs_when_exception_thrown(): void {
+		Functions\when( 'get_transient' )->alias(
+			static function () {
+				throw new \RuntimeException( 'boom' );
+			}
+		);
+		Functions\expect( 'update_option' )
+			->once()
+			->with( Core::LAST_ERROR_OPTION_KEY, \Mockery::pattern( '/boom/' ), false );
+
+		$core = new Core();
+		$this->assertSame( '', $core->add_shortcode( array() ) );
+	}
+
+	public function test_request_api_returns_null_when_no_access_token(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'get_option' )->alias(
+			static function ( $key, $default = false ) {
+				if ( Auth::REFRESH_TOKEN_OPTION_KEY === $key ) {
+					return ''; // no refresh token.
+				}
+				if ( Admin::OPTIONS_KEY === $key ) {
+					return array(
+						'client_id'     => 'cid',
+						'client_secret' => 'sec',
+						'callback_url'  => 'https://cb',
+					);
+				}
+				return $default;
+			}
+		);
+		// No refresh token + no code: wp_remote_post returns error (we make it 401).
+		Functions\when( 'wp_remote_post' )->justReturn( array() );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 401 );
+		Functions\expect( 'update_option' )
+			->once()
+			->with( Core::LAST_ERROR_OPTION_KEY, \Mockery::type( 'string' ), false );
+
+		$core   = new Core();
+		$result = $core->request_api(
+			array(
+				'q'      => '*',
+				'fields' => 'title',
+				'order'  => '',
+				'sort'   => 'desc',
+				'limit'  => 10,
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	public function test_request_api_returns_decoded_json_on_success(): void {
+		// Cached access token shortcut: no token negotiation needed.
+		Functions\when( 'get_transient' )->alias(
+			static function ( $key ) {
+				return Auth::ACCESS_TOKEN_TRANSIENT_KEY === $key ? 'cached-token' : false;
+			}
+		);
+
+		Functions\expect( 'wp_remote_get' )
+			->once()
+			->with(
+				Core::BASE_API_ITEMS_URL,
+				\Mockery::on(
+					static function ( $args ) {
+						return isset( $args['headers']['Authorization'] )
+							&& 'Bearer cached-token' === $args['headers']['Authorization']
+							&& 'kw' === $args['body']['q']
+							&& 5 === $args['body']['limit'];
+					}
+				)
+			)
+			->andReturn( array( 'body' => '{"items":[{"item_id":7,"title":"a"}]}' ) );
+
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"items":[{"item_id":7,"title":"a"}]}' );
+
+		$core   = new Core();
+		$result = $core->request_api(
+			array(
+				'q'      => 'kw',
+				'fields' => 'title',
+				'order'  => 'list_order',
+				'sort'   => 'asc',
+				'limit'  => 5,
+			)
+		);
+
+		$this->assertIsObject( $result );
+		$this->assertSame( 7, $result->items[0]->item_id );
+	}
+
+	public function test_request_api_returns_null_and_logs_on_non_200(): void {
+		Functions\when( 'get_transient' )->alias(
+			static function ( $key ) {
+				return Auth::ACCESS_TOKEN_TRANSIENT_KEY === $key ? 'tok' : false;
+			}
+		);
+		Functions\when( 'wp_remote_get' )->justReturn( array() );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 500 );
+		Functions\when( 'wp_remote_retrieve_response_message' )->justReturn( 'Server Error' );
+		Functions\expect( 'update_option' )
+			->once()
+			->with( Core::LAST_ERROR_OPTION_KEY, \Mockery::type( 'string' ), false );
+
+		$core = new Core();
+		$this->assertNull(
+			$core->request_api(
+				array(
+					'q'      => '*',
+					'fields' => 'title',
+					'order'  => '',
+					'sort'   => 'desc',
+					'limit'  => 10,
+				)
+			)
+		);
+	}
+
+	public function test_item_list_appends_shop_url_to_each_item(): void {
+		Functions\when( 'get_option' )->justReturn( array( 'shop_url' => 'https://shop.example/' ) );
+
+		$items = array(
+			(object) array(
+				'item_id'  => 1,
+				'title'    => 't1',
+				'img1_300' => 'https://i/1.jpg',
+			),
+			(object) array(
+				'item_id'  => 2,
+				'title'    => 't2',
+				'img1_300' => 'https://i/2.jpg',
+			),
+		);
+
+		$core   = new Core();
+		$output = $core->item_list( $items );
+
+		$this->assertStringContainsString( 'https://shop.example/items/1', $output );
+		$this->assertStringContainsString( 'https://shop.example/items/2', $output );
+		$this->assertStringContainsString( 't1', $output );
+		$this->assertStringContainsString( 't2', $output );
+	}
+
+	public function test_wp_enqueue_scripts_enqueues_default_style(): void {
+		Functions\when( 'get_option' )->justReturn( array( 'use_default_css' => '1' ) );
+		Functions\expect( 'wp_enqueue_style' )
+			->once()
+			->with( 'base-item-list', \Mockery::pattern( '#/assets/css/base-item-list\.css$#' ) );
+
+		( new Core() )->wp_enqueue_scripts();
+	}
+
+	/**
+	 * Build a partial Core mock whose request_api is never expected; useful when the test
+	 * exercises the cache-hit branch only.
+	 */
+	private function partial_core_without_request_api(): Core {
+		$core = \Mockery::mock( Core::class )->makePartial();
+		$core->shouldNotReceive( 'request_api' );
+		return $core;
+	}
+}

--- a/tests/Unit/ViewTest.php
+++ b/tests/Unit/ViewTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Tests for mt8\BaseItemList\Admin\View.
+ *
+ * @package mt8\BaseItemList\Tests
+ */
+
+namespace mt8\BaseItemList\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use mt8\BaseItemList\Admin\Admin;
+use mt8\BaseItemList\Admin\View;
+use mt8\BaseItemList\Tests\TestCase;
+
+class ViewTest extends TestCase {
+
+	public function test_filter_setting_blanks_missing_or_empty_required_fields(): void {
+		$result = View::filter_setting(
+			array(
+				'client_id'     => 'has-value',
+				'client_secret' => '   ', // whitespace-only → blanked.
+				// callback_url missing → blanked.
+				'shop_url'      => '',
+				'extra'         => 'preserved', // non-required key untouched.
+			)
+		);
+
+		$this->assertSame( 'has-value', $result['client_id'] );
+		$this->assertSame( '', $result['client_secret'] );
+		$this->assertSame( '', $result['callback_url'] );
+		$this->assertSame( '', $result['shop_url'] );
+		$this->assertSame( 'preserved', $result['extra'] );
+	}
+
+	public function test_filter_setting_returns_input_unchanged_when_all_required_fields_present(): void {
+		$input = array(
+			'client_id'     => 'a',
+			'client_secret' => 'b',
+			'callback_url'  => 'c',
+			'shop_url'      => 'd',
+		);
+
+		$this->assertSame( $input, View::filter_setting( $input ) );
+	}
+
+	public function test_register_setting_fields_registers_section_and_all_fields(): void {
+		$key     = Admin::OPTIONS_KEY;
+		$section = $key . '_section';
+
+		Functions\expect( 'register_setting' )
+			->once()
+			->with( $key . '_group', $key, \Mockery::type( 'array' ) );
+
+		Functions\expect( 'add_settings_section' )
+			->once()
+			->with( $section, '設定', \Mockery::type( 'array' ), $key );
+
+		Functions\expect( 'add_settings_field' )
+			->times( 5 )
+			->with(
+				\Mockery::anyOf( 'client_id', 'client_secret', 'callback_url', 'shop_url', 'use_default_css' ),
+				\Mockery::type( 'string' ),
+				\Mockery::type( 'array' ),
+				$key,
+				$section
+			);
+
+		View::register_setting_fields();
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * PHPUnit bootstrap for the BASE Item List plugin.
+ *
+ * Loads Composer's autoloader so plugin classes are available via PSR-4. WordPress
+ * core functions are mocked per-test with Brain Monkey, so a full WordPress install
+ * is not required.
+ *
+ * @package mt8\BaseItemList\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+require_once __DIR__ . '/TestCase.php';


### PR DESCRIPTION
closes #31

## 概要

リポジトリに単体テストとコーディング規約チェックがなかったため、`PHPUnit` と `PHPCS` を導入しました。BASE API への HTTP 呼び出しは Brain Monkey でモックしており、フル WordPress 環境を起動せず純粋な単体テストとして動作します。CI も `push` / `pull_request` で自動実行されるようにしました。

## 変更点

### ツール導入

- `composer.json` を新規作成。dev 依存として `phpunit/phpunit ^9.6`、`brain/monkey ^2.6`、`yoast/phpunit-polyfills ^2.0`、`wp-coding-standards/wpcs ^3.1`、`phpcompatibility/phpcompatibility-wp ^2.1` 等を追加
- `phpcs.xml.dist`: WPCS をベースに、`Squiz.Commenting.*` の docblock 必須ルールや `WordPress.PHP.DevelopmentFunctions.error_log_*`（意図的に使用）など、本プラグインの方針に合わないルールのみ除外
- `phpunit.xml.dist` + `tests/bootstrap.php`: Composer autoload + Brain Monkey でセットアップ。`error_log` の出力は `/dev/null` にリダイレクト
- `tests/TestCase.php`: 共通基底クラス。`esc_*` 等の純粋関数を一括スタブ

### テスト（計 30 件 / 60 アサーション）

- `tests/Unit/CoreTest.php`
  - `register_hooks` がフックとショートコードを正しく登録する
  - `add_shortcode` のキャッシュヒット / キャッシュミス / API 失敗 / 例外 / 不正パラメータの正規化
  - `request_api` のトークン未取得 / 200 成功 / 非 200 エラー
  - `item_list` が `shop_url` を各アイテムに付与してテンプレートを描画
  - `wp_enqueue_scripts` がデフォルト CSS をエンキュー
- `tests/Unit/AuthTest.php`
  - `get_access_token`: キャッシュヒット、`authorization_code` フロー、`refresh_token` フロー、非 200 応答、`use_cache=false`
  - `authorized()` の真偽分岐
- `tests/Unit/AdminTest.php`: `option`、`saved_options`、`admin_menu`、`admin_init` の早期 return
- `tests/Unit/ViewTest.php`: `filter_setting`、`register_setting_fields`（5 フィールド分の登録）

### CI

- `.github/workflows/ci.yml`: PHP 7.4 / 8.0 / 8.1 / 8.2 / 8.3 で PHPUnit を、最新版で PHPCS を実行

### 既存コードの修正（PHPCS 指摘のうち実害のあるもの）

| ファイル | 内容 |
| --- | --- |
| `template/base_items.php` | `$item->item_id` を `(int)` キャストで出力 |
| `includes/Admin/View.php` | `plugins_url()`・`Admin::OPTIONS_KEY` 出力を `esc_url()`・`esc_attr()` でエスケープ |
| `includes/Auth.php` | `parse_url` → `wp_parse_url`、`urlencode` → `rawurlencode`、`\$_SESSION['oauth_state']` を `isset()` + `sanitize_text_field()` で防御 |
| `includes/Admin/Admin.php` | `@session_start()` の `@` を取り `PHP_SESSION_NONE` で状態判定 |
| `includes/Core.php` | `extract()` を明示的代入に置換、`in_array()` を strict 比較に、`wp_enqueue_scripts` の `true \|\| ...` デッドコード除去 |

挙動は変えていません（テストはいずれの修正前後でもグリーンです）。

### 配布物

`.distignore` を更新し、`tests/`・`composer.phar`・`.phpunit.cache`・`CLAUDE.md` を wp.org 配布から除外。

## 動作確認

```bash
composer install
composer phpcs    # → エラー・警告 0
composer test     # → 30 tests, 60 assertions, OK
```

## レビュー観点

- 既存コードの挙動を変えていないか（特に `Core::add_shortcode` の `extract()` → 個別代入、`Core::wp_enqueue_scripts` の条件分岐削除）
- `PHPCS` ルール除外の妥当性
- BASE API のレスポンス構造のモックが実際と乖離していないか