### PR TITLE
OAuth エンドポイント URL をフィルタで上書き可能にする (#35)

### DIFF
--- a/includes/Auth.php
+++ b/includes/Auth.php
@@ -12,6 +12,23 @@ class Auth {
 	const ACCESS_TOKEN_TRANSIENT_KEY = 'base-item-list-access-token';
 	const REFRESH_TOKEN_OPTION_KEY   = 'base-item-list-refresh-token';
 
+	/**
+	 * Authorize endpoint, filterable via `base_item_list_auth_url`.
+	 *
+	 * Useful for pointing the OAuth flow at a mock server in dev/test environments
+	 * without touching production behaviour.
+	 */
+	public static function auth_endpoint(): string {
+		return (string) apply_filters( 'base_item_list_auth_url', self::BASE_API_AUTH_URL );
+	}
+
+	/**
+	 * Token exchange endpoint, filterable via `base_item_list_token_url`.
+	 */
+	public static function token_endpoint(): string {
+		return (string) apply_filters( 'base_item_list_token_url', self::BASE_API_TOKEN_URL );
+	}
+
 	public function authorize() {
 
 		if ( '1' === filter_input( INPUT_GET, 'force' ) ) {
@@ -52,7 +69,8 @@ class Auth {
 		$client_id    = Admin::option( 'client_id' );
 		$callback_url = Admin::option( 'callback_url' );
 
-		$auth_url = add_query_arg(
+		$auth_endpoint = self::auth_endpoint();
+		$auth_url      = add_query_arg(
 			array(
 				'response_type' => 'code',
 				'client_id'     => $client_id,
@@ -60,13 +78,13 @@ class Auth {
 				'scope'         => 'read_items',
 				'state'         => $state,
 			),
-			self::BASE_API_AUTH_URL
+			$auth_endpoint
 		);
 
 		add_filter(
 			'allowed_redirect_hosts',
-			function ( $allowed ) {
-				$allowed[] = wp_parse_url( self::BASE_API_AUTH_URL, PHP_URL_HOST );
+			function ( $allowed ) use ( $auth_endpoint ) {
+				$allowed[] = wp_parse_url( $auth_endpoint, PHP_URL_HOST );
 				return $allowed;
 			}
 		);
@@ -91,7 +109,7 @@ class Auth {
 		$refresh_token = get_option( self::REFRESH_TOKEN_OPTION_KEY );
 		if ( empty( $refresh_token ) ) {
 			$res = wp_remote_post(
-				self::BASE_API_TOKEN_URL,
+				self::token_endpoint(),
 				array(
 					'headers' => array(
 						'Content-Type: application/x-www-form-urlencoded',
@@ -107,7 +125,7 @@ class Auth {
 			);
 		} else {
 			$res = wp_remote_post(
-				self::BASE_API_TOKEN_URL,
+				self::token_endpoint(),
 				array(
 					'headers' => array(
 						'Content-Type: application/x-www-form-urlencoded',

--- a/includes/Core.php
+++ b/includes/Core.php
@@ -11,6 +11,14 @@ class Core {
 	const BASE_API_ITEMS_URL    = 'https://api.thebase.in/1/items/search';
 	const LAST_ERROR_OPTION_KEY = 'base-item-list-last-error';
 
+	/**
+	 * Items search endpoint, filterable via `base_item_list_items_url`. Useful for
+	 * routing requests at a mock BASE API server in dev/test environments.
+	 */
+	public static function items_endpoint(): string {
+		return (string) apply_filters( 'base_item_list_items_url', self::BASE_API_ITEMS_URL );
+	}
+
 	public function register_hooks() {
 
 		$admin = new Admin();
@@ -129,7 +137,7 @@ class Core {
 			),
 		);
 
-		$response = wp_remote_get( self::BASE_API_ITEMS_URL, $args );
+		$response = wp_remote_get( self::items_endpoint(), $args );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			error_log( '==========BASE Item List API Error==========' );

--- a/includes/Rest/SettingsController.php
+++ b/includes/Rest/SettingsController.php
@@ -120,7 +120,7 @@ class SettingsController {
 				'scope'         => 'read_items',
 				'state'         => $state,
 			),
-			Auth::BASE_API_AUTH_URL
+			Auth::auth_endpoint()
 		);
 
 		return rest_ensure_response( array( 'redirect_url' => $auth_url ) );

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,14 @@ BASE商品情報をリスト表示するショートコード:[BASE_ITEM] を使
 
 ※ BASE APIは事前に申請が必要です。https://developers.thebase.in/
 
+= 開発者向け: エンドポイント URL を差し替えるフィルタ =
+
+ローカル mock サーバ等への向き先変更のために以下のフィルタが利用できます。フィルタを登録しない限り本番挙動と同一です。
+
+* `base_item_list_auth_url`  : OAuth 認可エンドポイント (デフォルト: https://api.thebase.in/1/oauth/authorize)
+* `base_item_list_token_url` : OAuth トークン交換エンドポイント (デフォルト: https://api.thebase.in/1/oauth/token)
+* `base_item_list_items_url` : 商品検索 API エンドポイント (デフォルト: https://api.thebase.in/1/items/search)
+
 == Installation ==
 
 1. Upload `base-item-list.zip` to the `/wp-content/plugins/` directory

--- a/tests/Unit/FiltersTest.php
+++ b/tests/Unit/FiltersTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests that the three OAuth/items endpoint filters override the hardcoded URLs.
+ *
+ * @package mt8\BaseItemList\Tests
+ */
+
+namespace mt8\BaseItemList\Tests\Unit;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use mt8\BaseItemList\Auth;
+use mt8\BaseItemList\Core;
+use mt8\BaseItemList\Rest\SettingsController;
+use mt8\BaseItemList\Tests\TestCase;
+use WP_REST_Request;
+
+class FiltersTest extends TestCase {
+
+	public function test_auth_endpoint_returns_constant_when_no_filter(): void {
+		$this->assertSame( Auth::BASE_API_AUTH_URL, Auth::auth_endpoint() );
+	}
+
+	public function test_auth_endpoint_returns_filtered_value(): void {
+		Filters\expectApplied( 'base_item_list_auth_url' )
+			->once()
+			->with( Auth::BASE_API_AUTH_URL )
+			->andReturn( 'https://mock.test/authorize' );
+
+		$this->assertSame( 'https://mock.test/authorize', Auth::auth_endpoint() );
+	}
+
+	public function test_token_endpoint_returns_filtered_value(): void {
+		Filters\expectApplied( 'base_item_list_token_url' )
+			->once()
+			->with( Auth::BASE_API_TOKEN_URL )
+			->andReturn( 'https://mock.test/token' );
+
+		$this->assertSame( 'https://mock.test/token', Auth::token_endpoint() );
+	}
+
+	public function test_items_endpoint_returns_filtered_value(): void {
+		Filters\expectApplied( 'base_item_list_items_url' )
+			->once()
+			->with( Core::BASE_API_ITEMS_URL )
+			->andReturn( 'https://mock.test/items' );
+
+		$this->assertSame( 'https://mock.test/items', Core::items_endpoint() );
+	}
+
+	public function test_request_api_uses_filtered_items_url(): void {
+		Filters\expectApplied( 'base_item_list_items_url' )
+			->atLeast()
+			->once()
+			->andReturn( 'https://mock.test/items' );
+		Functions\when( 'get_transient' )->alias(
+			static function ( $key ) {
+				return Auth::ACCESS_TOKEN_TRANSIENT_KEY === $key ? 'tok' : false;
+			}
+		);
+		Functions\expect( 'wp_remote_get' )
+			->once()
+			->with( 'https://mock.test/items', \Mockery::type( 'array' ) )
+			->andReturn( array( 'body' => '{"items":[]}' ) );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"items":[]}' );
+
+		( new Core() )->request_api(
+			array(
+				'q'      => '*',
+				'fields' => 'title',
+				'order'  => '',
+				'sort'   => 'desc',
+				'limit'  => 10,
+			)
+		);
+	}
+
+	public function test_get_access_token_uses_filtered_token_url(): void {
+		Filters\expectApplied( 'base_item_list_token_url' )
+			->atLeast()
+			->once()
+			->andReturn( 'https://mock.test/token' );
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'get_option' )->justReturn( '' );
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'update_option' )->justReturn( true );
+		Functions\expect( 'wp_remote_post' )
+			->once()
+			->with( 'https://mock.test/token', \Mockery::type( 'array' ) )
+			->andReturn( array() );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn(
+			'{"access_token":"t","refresh_token":"r","expires_in":60}'
+		);
+
+		( new Auth() )->get_access_token( 'code' );
+	}
+
+	public function test_settings_controller_start_auth_uses_filtered_auth_url(): void {
+		Filters\expectApplied( 'base_item_list_auth_url' )
+			->atLeast()
+			->once()
+			->andReturn( 'https://mock.test/authorize' );
+
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'client_id'    => 'cid',
+				'callback_url' => 'https://cb.example/',
+			)
+		);
+		Functions\when( 'wp_generate_password' )->justReturn( 'state12chars' );
+		Functions\when( 'add_query_arg' )->alias(
+			static function ( array $args, string $url ) {
+				return $url . '?' . http_build_query( $args );
+			}
+		);
+		Functions\when( 'rest_ensure_response' )->alias(
+			static function ( $data ) {
+				return new \WP_REST_Response( $data, 200 );
+			}
+		);
+
+		$controller = \Mockery::mock( SettingsController::class )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+		$controller->shouldReceive( 'ensure_session_started' )->once();
+
+		$response = $controller->start_auth( new WP_REST_Request() );
+		$redirect = $response->get_data()['redirect_url'];
+
+		$this->assertStringStartsWith( 'https://mock.test/authorize?', $redirect );
+	}
+}


### PR DESCRIPTION
closes #35

> [!NOTE]
> **PR #34 にスタックしています。** base は \`33-build-pipeline\` で開いています。PR #34 がマージされたら base は自動で master に切り替わります。

## 概要

BASE OAuth / 商品検索 API の URL がクラス定数で固定だったため、ローカル mock OAuth サーバ等への向き先変更ができなかった。3 つのフィルタを追加して、フィルタ未登録時は完全に既存挙動を維持しつつ、開発・テスト時には差し替えられるようにする。

## 追加フィルタ

| フィルタ名 | デフォルト |
| --- | --- |
| \`base_item_list_auth_url\`  | \`https://api.thebase.in/1/oauth/authorize\` |
| \`base_item_list_token_url\` | \`https://api.thebase.in/1/oauth/token\` |
| \`base_item_list_items_url\` | \`https://api.thebase.in/1/items/search\` |

### 使用例（mu-plugin or wp-config の早期フック）

\`\`\`php
add_filter( 'base_item_list_auth_url',  fn() => 'http://localhost:8080/authorize' );
add_filter( 'base_item_list_token_url', fn() => 'http://localhost:8080/token' );
add_filter( 'base_item_list_items_url', fn() => 'http://localhost:8080/items' );
\`\`\`

## 変更点

- \`Auth::auth_endpoint()\` / \`Auth::token_endpoint()\` を新設し \`apply_filters\` 経由に
- \`Core::items_endpoint()\` を同様に新設
- \`Auth::get_auth_code\` / \`Auth::get_access_token\` / \`Core::request_api\` / \`Rest\\SettingsController::start_auth\` の URL 直参照を全てこれらのメソッドに置換
- \`allowed_redirect_hosts\` クロージャもフィルタ後のホストを参照
- 新規 PHPUnit 7 件で各フィルタの動作と HTTP リクエスト先を検証
- readme.txt にフィルタの存在を追記

## 動作確認

\`\`\`bash
composer phpcs    # → エラー 0
composer test     # → 47 tests, 107 assertions, OK
\`\`\`

## レビュー観点

- フィルタ未登録時にデフォルト値（クラス定数）が確実に返ること（テストでカバー済み）
- \`apply_filters\` の戻り値は文字列キャスト済み
- フィルタ名のプレフィックスが \`base_item_list_\` で統一されているか